### PR TITLE
src/libtsdb: Add missing <algorithm> header required for std::sort.

### DIFF
--- a/src/libtsdb/database.h
+++ b/src/libtsdb/database.h
@@ -5,6 +5,7 @@
 
 #include "exception.h"
 #include "root.h"
+#include <algorithm>
 
 namespace tsdb
 {

--- a/src/libtsdb/measurement.h
+++ b/src/libtsdb/measurement.h
@@ -7,6 +7,7 @@
 #include "constants.h"
 #include <futil/futil.h>
 #include <span>
+#include <algorithm>
 #include <hdr/kassert.h>
 #include <hdr/kmath.h>
 #include <hdr/static_vector.h>

--- a/src/libtsdb/root.cc
+++ b/src/libtsdb/root.cc
@@ -7,6 +7,7 @@
 #include <futil/xact.h>
 #include <futil/ssl.h>
 #include <strutil/strutil.h>
+#include <algorithm>
 
 const tsdb::configuration tsdb::default_configuration =
 {


### PR DESCRIPTION
Required on the latest Ubuntu server to build properly.