### PR TITLE
etc/fail2ban: Update to use systemd journal instead of /var/log/syslog.

### DIFF
--- a/etc/fail2ban/filter.d/tsdbserver.local
+++ b/etc/fail2ban/filter.d/tsdbserver.local
@@ -7,3 +7,4 @@ _daemon = tsdbserver
 failregex = ^%(__prefix_line)sZombie detected: <HOST>:\d+$
             ^%(__prefix_line)sSSL wrap failure: <HOST>:\d+ .*$
             ^%(__prefix_line)sAuthentication from <HOST>:\d+ .* failed\.$
+journalmatch = _SYSTEMD_UNIT=tsdbserver.service

--- a/etc/fail2ban/jail.d/tsdbserver.local
+++ b/etc/fail2ban/jail.d/tsdbserver.local
@@ -1,5 +1,5 @@
 [tsdbserver]
 enabled = true
+backend = systemd[journalflags=1]
 port = 4000
 filter = tsdbserver
-logpath = /var/log/syslog


### PR DESCRIPTION
This will help avoid any issues with syslog log rotation.